### PR TITLE
Add utility method to find TimeSeries with in_domainId & out_domainId

### DIFF
--- a/src/main/java/com/powsybl/balances_adjustment/data_exchange/DataExchanges.java
+++ b/src/main/java/com/powsybl/balances_adjustment/data_exchange/DataExchanges.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  *  Pan European Verification Function (PEVF) &
@@ -169,6 +170,18 @@ public class DataExchanges {
             throw new PowsyblException(String.format("TimeSeries '%s' not found", timeSeriesId));
         }
         return timeSeriesById.get(timeSeriesId);
+    }
+
+    public Stream<DoubleTimeSeries> getTimeSeriesStream(String inDomainId, String outDomainId) {
+        return getTimeSeries().stream().filter(t -> {
+            java.util.Map<java.lang.String, java.lang.String> tags = t.getMetadata().getTags();
+            return inDomainId.equalsIgnoreCase(tags.get(DataExchangesConstants.IN_DOMAIN + "." + DataExchangesConstants.MRID)) &&
+                    outDomainId.equalsIgnoreCase(tags.get(DataExchangesConstants.OUT_DOMAIN + "." + DataExchangesConstants.MRID));
+        });
+    }
+
+    public List<DoubleTimeSeries> getTimeSeries(String inDomainId, String outDomainId) {
+        return getTimeSeriesStream(inDomainId, outDomainId).collect(Collectors.toList());
     }
 
     public Map<String, Double> getValuesAt(Instant instant) {

--- a/src/main/java/com/powsybl/balances_adjustment/data_exchange/DataExchanges.java
+++ b/src/main/java/com/powsybl/balances_adjustment/data_exchange/DataExchanges.java
@@ -174,21 +174,16 @@ public class DataExchanges {
         return timeSeriesByMetadata.get(key.get());
     }
 
-    private boolean search(TimeSeriesMetadata metaData, String inDomainId, String outDomainId) {
-        java.util.Map<java.lang.String, java.lang.String> tags = metaData.getTags();
-        return inDomainId.equalsIgnoreCase(tags.get(DataExchangesConstants.IN_DOMAIN + "." + DataExchangesConstants.MRID)) &&
-                outDomainId.equalsIgnoreCase(tags.get(DataExchangesConstants.OUT_DOMAIN + "." + DataExchangesConstants.MRID));
-    }
-
     public List<DoubleTimeSeries> getTimeSeries(String inDomainId, String outDomainId) {
         Objects.requireNonNull(inDomainId, IN_DOMAIN_ID_CANNOT_BE_NULL);
         Objects.requireNonNull(outDomainId, OUT_DOMAIN_ID_CANNOT_BE_NULL);
-        List<TimeSeriesMetadata> keys = timeSeriesByMetadata.keySet().stream().filter(metaData -> search(metaData, inDomainId, outDomainId)).collect(Collectors.toList());
-        return keys.stream().map(timeSeriesByMetadata::get).collect(Collectors.toList());
-    }
+        List<TimeSeriesMetadata> keys = timeSeriesByMetadata.keySet().stream().filter(metaData -> {
+            java.util.Map<java.lang.String, java.lang.String> tags = metaData.getTags();
+            return inDomainId.equalsIgnoreCase(tags.get(DataExchangesConstants.IN_DOMAIN + "." + DataExchangesConstants.MRID)) &&
+                    outDomainId.equalsIgnoreCase(tags.get(DataExchangesConstants.OUT_DOMAIN + "." + DataExchangesConstants.MRID));
+        }).collect(Collectors.toList());
 
-    public List<DoubleTimeSeries> getTimeSeries2(String inDomainId, String outDomainId) {
-        return getTimeSeries().stream().filter(t -> search(t.getMetadata(), inDomainId, outDomainId)).collect(Collectors.toList());
+        return keys.stream().map(timeSeriesByMetadata::get).collect(Collectors.toList());
     }
 
     public Map<String, Double> getValuesAt(Instant instant) {

--- a/src/main/java/com/powsybl/balances_adjustment/data_exchange/DataExchanges.java
+++ b/src/main/java/com/powsybl/balances_adjustment/data_exchange/DataExchanges.java
@@ -29,8 +29,6 @@ public class DataExchanges {
     private static final String INSTANT_CANNOT_BE_NULL = "Instant cannot be null";
     private static final String ID_CANNOT_BE_NULL = "TimeSeriesId cannot be null";
     private static final String IDS_CANNOT_BE_NULL = "TimeSeriesIds cannot be null";
-    private static final String IN_DOMAIN_ID_CANNOT_BE_NULL = "inDomainId cannot be null";
-    private static final String OUT_DOMAIN_ID_CANNOT_BE_NULL = "outDomainId cannot be null";
 
     /** Document identification. */
     private final String mRID;
@@ -67,12 +65,12 @@ public class DataExchanges {
     private final StandardCodingSchemeType domainCodingScheme;
 
     // Time Series
-    private final Map<TimeSeriesMetadata, DoubleTimeSeries> timeSeriesByMetadata = new HashMap<>();
+    private final Map<String, DoubleTimeSeries> timeSeriesById = new HashMap<>();
 
     DataExchanges(String mRID, int revisionNumber, StandardMessageType type, StandardProcessType processType,
                   String senderId, StandardCodingSchemeType senderCodingScheme, StandardRoleType senderMarketRole,
                   String receiverId, StandardCodingSchemeType receiverCodingScheme, StandardRoleType receiverMarketRole,
-                  DateTime creationDate, Interval period, String datasetMarketDocumentMRId, StandardStatusType docStatus, Map<TimeSeriesMetadata, StoredDoubleTimeSeries> timeSeriesByMetadata,
+                  DateTime creationDate, Interval period, String datasetMarketDocumentMRId, StandardStatusType docStatus, Map<String, StoredDoubleTimeSeries> timeSeriesById,
                   String domainId, StandardCodingSchemeType domainCodingScheme) {
         this.mRID = Objects.requireNonNull(mRID, "mRID is missing");
         this.revisionNumber = checkRevisionNumber(revisionNumber);
@@ -86,7 +84,7 @@ public class DataExchanges {
         this.receiverMarketRole = Objects.requireNonNull(receiverMarketRole, "Receiver role is missing");
         this.creationDate = Objects.requireNonNull(creationDate, "Creation DateTime is missing");
         this.period = Objects.requireNonNull(period, "Time interval is missing");
-        this.timeSeriesByMetadata.putAll(timeSeriesByMetadata);
+        this.timeSeriesById.putAll(timeSeriesById);
         // Optional data
         this.datasetMarketDocumentMRId = datasetMarketDocumentMRId;
         this.docStatus = docStatus;
@@ -162,34 +160,22 @@ public class DataExchanges {
 
     // Utilities
     public Collection<DoubleTimeSeries> getTimeSeries() {
-        return Collections.unmodifiableCollection(timeSeriesByMetadata.values());
+        return Collections.unmodifiableCollection(timeSeriesById.values());
     }
 
     public DoubleTimeSeries getTimeSeries(String timeSeriesId) {
         Objects.requireNonNull(timeSeriesId, ID_CANNOT_BE_NULL);
-        Optional<TimeSeriesMetadata> key = timeSeriesByMetadata.keySet().stream().filter(metadata -> metadata.getName().equalsIgnoreCase(timeSeriesId)).findAny();
-        if (!key.isPresent()) {
+        if (!timeSeriesById.containsKey(timeSeriesId)) {
             throw new PowsyblException(String.format("TimeSeries '%s' not found", timeSeriesId));
         }
-        return timeSeriesByMetadata.get(key.get());
-    }
-
-    public List<DoubleTimeSeries> getTimeSeries(String inDomainId, String outDomainId) {
-        Objects.requireNonNull(inDomainId, IN_DOMAIN_ID_CANNOT_BE_NULL);
-        Objects.requireNonNull(outDomainId, OUT_DOMAIN_ID_CANNOT_BE_NULL);
-        List<TimeSeriesMetadata> keys = timeSeriesByMetadata.keySet().stream().filter(metaData -> {
-            java.util.Map<java.lang.String, java.lang.String> tags = metaData.getTags();
-            return inDomainId.equalsIgnoreCase(tags.get(DataExchangesConstants.IN_DOMAIN + "." + DataExchangesConstants.MRID)) &&
-                    outDomainId.equalsIgnoreCase(tags.get(DataExchangesConstants.OUT_DOMAIN + "." + DataExchangesConstants.MRID));
-        }).collect(Collectors.toList());
-
-        return keys.stream().map(timeSeriesByMetadata::get).collect(Collectors.toList());
+        return timeSeriesById.get(timeSeriesId);
     }
 
     public Map<String, Double> getValuesAt(Instant instant) {
         Objects.requireNonNull(instant, INSTANT_CANNOT_BE_NULL);
-        return timeSeriesByMetadata.keySet().stream()
-                .collect(Collectors.toMap(TimeSeriesMetadata::getName, metadata -> getValueAt(getTimeSeries(metadata.getName()), instant)));
+
+        return timeSeriesById.keySet().stream()
+                .collect(Collectors.toMap(id -> id, id -> getValueAt(getTimeSeries(id), instant)));
     }
 
     public double getValueAt(String timeSeriesId, Instant instant) {

--- a/src/main/java/com/powsybl/balances_adjustment/data_exchange/DataExchanges.java
+++ b/src/main/java/com/powsybl/balances_adjustment/data_exchange/DataExchanges.java
@@ -174,16 +174,21 @@ public class DataExchanges {
         return timeSeriesByMetadata.get(key.get());
     }
 
+    private boolean search(TimeSeriesMetadata metaData, String inDomainId, String outDomainId) {
+        java.util.Map<java.lang.String, java.lang.String> tags = metaData.getTags();
+        return inDomainId.equalsIgnoreCase(tags.get(DataExchangesConstants.IN_DOMAIN + "." + DataExchangesConstants.MRID)) &&
+                outDomainId.equalsIgnoreCase(tags.get(DataExchangesConstants.OUT_DOMAIN + "." + DataExchangesConstants.MRID));
+    }
+
     public List<DoubleTimeSeries> getTimeSeries(String inDomainId, String outDomainId) {
         Objects.requireNonNull(inDomainId, IN_DOMAIN_ID_CANNOT_BE_NULL);
         Objects.requireNonNull(outDomainId, OUT_DOMAIN_ID_CANNOT_BE_NULL);
-        List<TimeSeriesMetadata> keys = timeSeriesByMetadata.keySet().stream().filter(metaData -> {
-            java.util.Map<java.lang.String, java.lang.String> tags = metaData.getTags();
-            return inDomainId.equalsIgnoreCase(tags.get(DataExchangesConstants.IN_DOMAIN + "." + DataExchangesConstants.MRID)) &&
-                    outDomainId.equalsIgnoreCase(tags.get(DataExchangesConstants.OUT_DOMAIN + "." + DataExchangesConstants.MRID));
-        }).collect(Collectors.toList());
-
+        List<TimeSeriesMetadata> keys = timeSeriesByMetadata.keySet().stream().filter(metaData -> search(metaData, inDomainId, outDomainId)).collect(Collectors.toList());
         return keys.stream().map(timeSeriesByMetadata::get).collect(Collectors.toList());
+    }
+
+    public List<DoubleTimeSeries> getTimeSeries2(String inDomainId, String outDomainId) {
+        return getTimeSeries().stream().filter(t -> search(t.getMetadata(), inDomainId, outDomainId)).collect(Collectors.toList());
     }
 
     public Map<String, Double> getValuesAt(Instant instant) {

--- a/src/main/java/com/powsybl/balances_adjustment/data_exchange/DataExchangesXml.java
+++ b/src/main/java/com/powsybl/balances_adjustment/data_exchange/DataExchangesXml.java
@@ -42,7 +42,7 @@ public final class DataExchangesXml {
 
     private static class ParsingContext {
 
-        private final Map<TimeSeriesMetadata, StoredDoubleTimeSeries> timeSeriesByMetadata = new HashMap<>();
+        private final Map<String, StoredDoubleTimeSeries> timeSeriesById = new HashMap<>();
 
         private StandardStatusType docStatus;
 
@@ -173,7 +173,7 @@ public final class DataExchangesXml {
 
                         case DataExchangesConstants.TIMESERIES:
                             StoredDoubleTimeSeries timeSeries = readTimeSeries(xmlReader);
-                            context.timeSeriesByMetadata.put(timeSeries.getMetadata(), timeSeries);
+                            context.timeSeriesById.put(timeSeries.getMetadata().getName(), timeSeries);
                             break;
 
                         case DataExchangesConstants.ROOT:
@@ -194,7 +194,7 @@ public final class DataExchangesXml {
         return new DataExchanges(context.mRID, context.revisionNumber, context.type, context.processType,
                                  context.senderId, context.senderCodingScheme, context.senderMarketRole,
                                  context.receiverId, context.receiverCodingScheme, context.receiverMarketRole,
-                                 context.creationDate, context.period, context.datasetMarketDocumentMRId, context.docStatus, context.timeSeriesByMetadata,
+                                 context.creationDate, context.period, context.datasetMarketDocumentMRId, context.docStatus, context.timeSeriesById,
                                  context.domainId, context.domainCodingScheme);
     }
 

--- a/src/main/java/com/powsybl/balances_adjustment/data_exchange/DataExchangesXml.java
+++ b/src/main/java/com/powsybl/balances_adjustment/data_exchange/DataExchangesXml.java
@@ -42,7 +42,7 @@ public final class DataExchangesXml {
 
     private static class ParsingContext {
 
-        private final Map<String, StoredDoubleTimeSeries> timeSeriesById = new HashMap<>();
+        private final Map<TimeSeriesMetadata, StoredDoubleTimeSeries> timeSeriesByMetadata = new HashMap<>();
 
         private StandardStatusType docStatus;
 
@@ -173,7 +173,7 @@ public final class DataExchangesXml {
 
                         case DataExchangesConstants.TIMESERIES:
                             StoredDoubleTimeSeries timeSeries = readTimeSeries(xmlReader);
-                            context.timeSeriesById.put(timeSeries.getMetadata().getName(), timeSeries);
+                            context.timeSeriesByMetadata.put(timeSeries.getMetadata(), timeSeries);
                             break;
 
                         case DataExchangesConstants.ROOT:
@@ -194,7 +194,7 @@ public final class DataExchangesXml {
         return new DataExchanges(context.mRID, context.revisionNumber, context.type, context.processType,
                                  context.senderId, context.senderCodingScheme, context.senderMarketRole,
                                  context.receiverId, context.receiverCodingScheme, context.receiverMarketRole,
-                                 context.creationDate, context.period, context.datasetMarketDocumentMRId, context.docStatus, context.timeSeriesById,
+                                 context.creationDate, context.period, context.datasetMarketDocumentMRId, context.docStatus, context.timeSeriesByMetadata,
                                  context.domainId, context.domainCodingScheme);
     }
 

--- a/src/test/java/com/powsybl/balances_adjustment/data_exchange/PevfExchangesTest.java
+++ b/src/test/java/com/powsybl/balances_adjustment/data_exchange/PevfExchangesTest.java
@@ -124,7 +124,8 @@ public class PevfExchangesTest {
 
     @Test
     public void searchTimeSeriesByDomainIdTest() {
-        assertEquals(0, exchanges.getTimeSeries("Invalid", "Invalid").size());
+        assertEquals(0, exchanges.getTimeSeries("Sender1", "Invalid").size());
+        assertEquals(0, exchanges.getTimeSeries("Invalid", "Receiver1").size());
         assertEquals(1, exchanges.getTimeSeries("Sender1", "Receiver1").size());
         assertThrows(NullPointerException.class, () -> exchanges.getTimeSeries(null, "Receiver1"));
         assertThrows(NullPointerException.class, () -> exchanges.getTimeSeries("Sender1", null));

--- a/src/test/java/com/powsybl/balances_adjustment/data_exchange/PevfExchangesTest.java
+++ b/src/test/java/com/powsybl/balances_adjustment/data_exchange/PevfExchangesTest.java
@@ -123,14 +123,6 @@ public class PevfExchangesTest {
     }
 
     @Test
-    public void searchTimeSeriesByDomainIdTest() {
-        assertEquals(0, exchanges.getTimeSeries("Invalid", "Invalid").size());
-        assertEquals(1, exchanges.getTimeSeries("Sender1", "Receiver1").size());
-        assertThrows(NullPointerException.class, () -> exchanges.getTimeSeries(null, "Receiver1"));
-        assertThrows(NullPointerException.class, () -> exchanges.getTimeSeries("Sender1", null));
-    }
-
-    @Test
     public void timeSeriesNotFoundTest() {
         exception.expect(PowsyblException.class);
         exception.expectMessage("TimeSeries 'Unknown' not found");

--- a/src/test/java/com/powsybl/balances_adjustment/data_exchange/PevfExchangesTest.java
+++ b/src/test/java/com/powsybl/balances_adjustment/data_exchange/PevfExchangesTest.java
@@ -123,6 +123,14 @@ public class PevfExchangesTest {
     }
 
     @Test
+    public void searchTimeSeriesByDomainIdTest() {
+        assertEquals(0, exchanges.getTimeSeries("Invalid", "Invalid").size());
+        assertEquals(1, exchanges.getTimeSeries("Sender1", "Receiver1").size());
+        assertThrows(NullPointerException.class, () -> exchanges.getTimeSeries(null, "Receiver1"));
+        assertThrows(NullPointerException.class, () -> exchanges.getTimeSeries("Sender1", null));
+    }
+
+    @Test
     public void timeSeriesNotFoundTest() {
         exception.expect(PowsyblException.class);
         exception.expectMessage("TimeSeries 'Unknown' not found");


### PR DESCRIPTION
Signed-off-by: Thomas ADAM <tadam@silicom.fr>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Today inDomain ID & outDomain ID are only available in TimeSeriesMetadata but it's really ofthen used to find timeseries with interest


**What is the new behavior (if this is a feature change)?**
Get Timeseries inDomain ID & outDomain ID as research parameter


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
