### PR TITLE
Add util methods in DataExchanges to retrieve the net position

### DIFF
--- a/src/main/java/com/powsybl/balances_adjustment/data_exchange/DataExchanges.java
+++ b/src/main/java/com/powsybl/balances_adjustment/data_exchange/DataExchanges.java
@@ -190,8 +190,12 @@ public class DataExchanges {
     }
 
     public double getNetPosition(String inDomainId, String outDomainId, Instant instant) {
-        return getValuesAt(inDomainId, outDomainId, instant, false).values().stream().reduce(0d, Double::sum)
-                - getValuesAt(outDomainId, inDomainId, instant, false).values().stream().reduce(0d, Double::sum);
+        return getNetPosition(inDomainId, outDomainId, instant, true);
+    }
+
+    public double getNetPosition(String inDomainId, String outDomainId, Instant instant, boolean exceptionOutOfBound) {
+        return getValuesAt(inDomainId, outDomainId, instant, exceptionOutOfBound).values().stream().reduce(0d, Double::sum)
+                - getValuesAt(outDomainId, inDomainId, instant, exceptionOutOfBound).values().stream().reduce(0d, Double::sum);
     }
 
     public Map<String, Double> getValuesAt(Instant instant) {

--- a/src/test/java/com/powsybl/balances_adjustment/data_exchange/PevfExchangesTest.java
+++ b/src/test/java/com/powsybl/balances_adjustment/data_exchange/PevfExchangesTest.java
@@ -137,7 +137,7 @@ public class PevfExchangesTest {
         assertEquals(0.0, values.get("TimeSeries1"), 0.0);
 
         assertEquals(0.0, exchanges.getNetPosition("Sender1", "Receiver1", Instant.parse("2020-04-05T22:00:00.000Z")), 0.0);
-        assertEquals(0.0, exchanges.getNetPosition("Sender1", "Receiver1", Instant.parse("2020-04-05T23:00:00.000Z")), 0.0);
+        assertEquals(0.0, exchanges.getNetPosition("Sender1", "Receiver1", Instant.parse("2020-04-05T23:00:00.000Z"), false), 0.0);
     }
 
     @Test

--- a/src/test/java/com/powsybl/balances_adjustment/data_exchange/PevfExchangesTest.java
+++ b/src/test/java/com/powsybl/balances_adjustment/data_exchange/PevfExchangesTest.java
@@ -129,6 +129,15 @@ public class PevfExchangesTest {
         assertEquals(1, exchanges.getTimeSeries("Sender1", "Receiver1").size());
         assertThrows(NullPointerException.class, () -> exchanges.getTimeSeries(null, "Receiver1"));
         assertThrows(NullPointerException.class, () -> exchanges.getTimeSeries("Sender1", null));
+
+        assertTrue(exchanges.getValuesAt("Sender1", "Invalid", Instant.parse("2020-04-05T22:00:00.000Z")).isEmpty());
+        Map<String, Double> values = exchanges.getValuesAt("Sender1", "Receiver1", Instant.parse("2020-04-05T22:00:00.000Z"));
+        assertEquals(1, values.size());
+        assertTrue(values.containsKey("TimeSeries1"));
+        assertEquals(0.0, values.get("TimeSeries1"), 0.0);
+
+        assertEquals(0.0, exchanges.getNetPosition("Sender1", "Receiver1", Instant.parse("2020-04-05T22:00:00.000Z")), 0.0);
+        assertEquals(0.0, exchanges.getNetPosition("Sender1", "Receiver1", Instant.parse("2020-04-05T23:00:00.000Z")), 0.0);
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: RALAMBOTIANA MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
New feature


**What is the current behavior?** *(You can also link to an open issue here)*
When trying to retrieve the net position, a user has to code quite a long bit of code


**What is the new behavior (if this is a feature change)?**
Util methods allowing the user to easily retrieve the net position have been added


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No

