### PR TITLE
Add border exchange computation for country area only

### DIFF
--- a/src/main/java/com/powsybl/balances_adjustment/util/CountryArea.java
+++ b/src/main/java/com/powsybl/balances_adjustment/util/CountryArea.java
@@ -61,20 +61,21 @@ public class CountryArea implements NetworkArea {
         return Collections.unmodifiableCollection(busesCache);
     }
 
-    public double getLeavingFlowToCountry(Country country) {
-        if (countries.contains(country)) {
-            throw new PowsyblException("The country " + country.getName() + " is contained in the control area");
-        }
+    public double getLeavingFlowToCountry(CountryArea countryArea) {
+        countryArea.getCountries().stream().forEach(country -> {
+            if (countries.contains(country)) {
+                throw new PowsyblException("The leaving flow to the country area cannot be computed. " +
+                        "The country " + country.getName() + " is contained in both control areas.");
+            }
+        });
         double sum = 0;
         for (Line line : lineBordersCache) {
-            if (line.getTerminal1().getVoltageLevel().getSubstation().get().getCountry().get().equals(country)
-                    || line.getTerminal2().getVoltageLevel().getSubstation().get().getCountry().get().equals(country)) {
+            if (countryArea.isAreaBorder(line)) {
                 sum += getLeavingFlow(line);
             }
         }
         for (HvdcLine line : hvdcLineBordersCache) {
-            if (line.getConverterStation1().getTerminal().getVoltageLevel().getSubstation().get().getCountry().get().equals(country)
-                    || line.getConverterStation2().getTerminal().getVoltageLevel().getSubstation().get().getCountry().get().equals(country)) {
+            if (countryArea.isAreaBorder(line)) {
                 sum += getLeavingFlow(line);
             }
         }

--- a/src/main/java/com/powsybl/balances_adjustment/util/CountryArea.java
+++ b/src/main/java/com/powsybl/balances_adjustment/util/CountryArea.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.balances_adjustment.util;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 
 import java.util.*;
@@ -58,6 +59,26 @@ public class CountryArea implements NetworkArea {
     @Override
     public Collection<Bus> getContainedBusViewBuses() {
         return Collections.unmodifiableCollection(busesCache);
+    }
+
+    public double getLeavingFlowToCountry(Country country) {
+        if (countries.contains(country)) {
+            throw new PowsyblException("The country " + country.getName() + " is contained in the control area");
+        }
+        double sum = 0;
+        for (Line line : lineBordersCache) {
+            if (line.getTerminal1().getVoltageLevel().getSubstation().get().getCountry().get().equals(country)
+                    || line.getTerminal2().getVoltageLevel().getSubstation().get().getCountry().get().equals(country)) {
+                sum += getLeavingFlow(line);
+            }
+        }
+        for (HvdcLine line : hvdcLineBordersCache) {
+            if (line.getConverterStation1().getTerminal().getVoltageLevel().getSubstation().get().getCountry().get().equals(country)
+                    || line.getConverterStation2().getTerminal().getVoltageLevel().getSubstation().get().getCountry().get().equals(country)) {
+                sum += getLeavingFlow(line);
+            }
+        }
+        return sum;
     }
 
     private boolean isAreaBorder(DanglingLine danglingLine) {

--- a/src/test/java/com/powsybl/balances_adjustment/util/CountryAreaTest.java
+++ b/src/test/java/com/powsybl/balances_adjustment/util/CountryAreaTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.balances_adjustment.util;
 
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.import_.Importers;
 import com.powsybl.iidm.network.*;
 import org.junit.Before;
@@ -27,6 +28,7 @@ public class CountryAreaTest {
 
     private CountryAreaFactory countryAreaFR;
     private CountryAreaFactory countryAreaES;
+    private CountryAreaFactory countryAreaBE;
 
     @Before
     public void setUp() {
@@ -35,7 +37,7 @@ public class CountryAreaTest {
 
         countryAreaFR = new CountryAreaFactory(Country.FR);
         countryAreaES = new CountryAreaFactory(Country.ES);
-
+        countryAreaBE = new CountryAreaFactory(Country.BE);
     }
 
     private Stream<Injection> getInjectionStream(Network network) {
@@ -74,5 +76,20 @@ public class CountryAreaTest {
         Network network = Importers.loadNetwork("testCaseSpecialDevices.xiidm", getClass().getResourceAsStream("/testCaseSpecialDevices.xiidm"));
         assertEquals(100, countryAreaFR.create(network).getNetPosition(), 1e-3);
         assertEquals(-100, countryAreaES.create(network).getNetPosition(), 1e-3);
+    }
+
+    @Test
+    public void testGetLeavingFlowToCountry() {
+        assertEquals(100.0, countryAreaFR.create(testNetwork2).getLeavingFlowToCountry(Country.ES), 1e-3);
+        assertEquals(-100.0, countryAreaES.create(testNetwork2).getLeavingFlowToCountry(Country.FR), 1e-3);
+        assertEquals(-324.666, countryAreaFR.create(testNetwork1).getLeavingFlowToCountry(Country.BE), 1e-3);
+        assertEquals(324.666, countryAreaBE.create(testNetwork1).getLeavingFlowToCountry(Country.FR), 1e-3);
+        assertEquals(0.0, countryAreaBE.create(testNetwork1).getLeavingFlowToCountry(Country.ES), 1e-3);
+        try {
+            countryAreaFR.create(testNetwork1).getLeavingFlowToCountry(Country.FR);
+            fail();
+        } catch (PowsyblException e) {
+            assertEquals("The country FRANCE is contained in the control area", e.getMessage());
+        }
     }
 }

--- a/src/test/java/com/powsybl/balances_adjustment/util/CountryAreaTest.java
+++ b/src/test/java/com/powsybl/balances_adjustment/util/CountryAreaTest.java
@@ -80,16 +80,22 @@ public class CountryAreaTest {
 
     @Test
     public void testGetLeavingFlowToCountry() {
-        assertEquals(100.0, countryAreaFR.create(testNetwork2).getLeavingFlowToCountry(Country.ES), 1e-3);
-        assertEquals(-100.0, countryAreaES.create(testNetwork2).getLeavingFlowToCountry(Country.FR), 1e-3);
-        assertEquals(-324.666, countryAreaFR.create(testNetwork1).getLeavingFlowToCountry(Country.BE), 1e-3);
-        assertEquals(324.666, countryAreaBE.create(testNetwork1).getLeavingFlowToCountry(Country.FR), 1e-3);
-        assertEquals(0.0, countryAreaBE.create(testNetwork1).getLeavingFlowToCountry(Country.ES), 1e-3);
+        CountryArea countryAreaFR2 = countryAreaFR.create(testNetwork2);
+        CountryArea countryAreaES2 = countryAreaES.create(testNetwork2);
+        CountryArea countryAreaFR1 = countryAreaFR.create(testNetwork1);
+        CountryArea countryAreaBE1 = countryAreaBE.create(testNetwork1);
+        CountryArea countryAreaES1 = countryAreaES.create(testNetwork1);
+
+        assertEquals(100.0, countryAreaFR2.getLeavingFlowToCountry(countryAreaES2), 1e-3);
+        assertEquals(-100.0, countryAreaES2.getLeavingFlowToCountry(countryAreaFR2), 1e-3);
+        assertEquals(-324.666, countryAreaFR1.getLeavingFlowToCountry(countryAreaBE1), 1e-3);
+        assertEquals(324.666, countryAreaBE1.getLeavingFlowToCountry(countryAreaFR1), 1e-3);
+        assertEquals(0.0, countryAreaBE1.getLeavingFlowToCountry(countryAreaES1), 1e-3);
         try {
-            countryAreaFR.create(testNetwork1).getLeavingFlowToCountry(Country.FR);
+            countryAreaFR.create(testNetwork1).getLeavingFlowToCountry(countryAreaFR1);
             fail();
         } catch (PowsyblException e) {
-            assertEquals("The country FRANCE is contained in the control area", e.getMessage());
+            assertEquals("The leaving flow to the country area cannot be computed. The country FRANCE is contained in both control areas.", e.getMessage());
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <anne.tilloy@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No.

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

We have four implementations of the `NetworkArea` interface. In this PR, for country area implementation only, we offer the possibility to compute the leaving flow in MW to a dedicated country. The feature is really simple and I think the concept could be apply to the other implementations but there is no need from now.  

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
